### PR TITLE
Icons overlapping.

### DIFF
--- a/js/grid.js
+++ b/js/grid.js
@@ -19,9 +19,9 @@ Grid.setDiameter = function () {
   // Checking which is smaller, the windows height or width.
   // The smallest one determines the diameter of the cells.
   if ($(window).height() > $(window).width()) {
-    this.diameter = ($(window).width()-($(window).width() / 8)) /  this.amount;
+    this.diameter = ($(window).width()-($(window).width() / 7.5)) /  this.amount;
   }else{
-    this.diameter = ($(window).height()-($(window).width() / 8)) /  this.amount;
+    this.diameter = ($(window).height()-($(window).width() / 7.5)) /  this.amount;
   }
 
 }


### PR DESCRIPTION
Icons were overlapping the grid in some cases. Making the grid a bit
smaller will prevent some (not all) of those cases.
